### PR TITLE
Respect file argument to print_x functions

### DIFF
--- a/rfc_bibtex/utils.py
+++ b/rfc_bibtex/utils.py
@@ -1,13 +1,13 @@
 import sys
 
 def print_red(text, end='\n', file=sys.stdout):
-    print(f'\u001b[1m\u001b[31m{text}\u001b[0m', end=end)
+    print(f'\u001b[1m\u001b[31m{text}\u001b[0m', end=end, file=file)
 
 def print_green(text, end='\n', file=sys.stdout):
-    print(f'\u001b[1m\u001b[32m{text}\u001b[0m', end=end)
+    print(f'\u001b[1m\u001b[32m{text}\u001b[0m', end=end, file=file)
 
 def print_yellow(text, end='\n', file=sys.stdout):
-    print(f'\u001b[33m\u001b[33m{text}\u001b[0m', end=end)
+    print(f'\u001b[33m\u001b[33m{text}\u001b[0m', end=end, file=file)
 
 def print_magenta(text, end='\n', file=sys.stdout):
-    print(f'\u001b[35m\u001b[31m{text}\u001b[0m', end=end)
+    print(f'\u001b[35m\u001b[31m{text}\u001b[0m', end=end, file=file)


### PR DESCRIPTION
The utils.print_x functions take a `file` argument that was not used in their implementation. This lead to errors and warnings being printed to stdout instead of stderr.

Fixes #33